### PR TITLE
Add a test program which reuses variables

### DIFF
--- a/ch07_untyped/test.cpp
+++ b/ch07_untyped/test.cpp
@@ -1001,6 +1001,10 @@ void InitData() {
     kData.emplace_back(
         TestData{"(l b. l c. b c l t. l f. f) (l t. l f. t) (l t. l f. f)",
                  Lambda("t", Lambda("f", Term::Variable("f", 0)))});
+
+    kData.emplace_back(
+        TestData{"(l x. x x) y",
+                 Term::Application(VariableUP("y", 24), VariableUP("y", 24))});
 }
 
 void Run() {

--- a/ch07_untyped/test.cpp
+++ b/ch07_untyped/test.cpp
@@ -1005,6 +1005,10 @@ void InitData() {
     kData.emplace_back(
         TestData{"(l x. x x) y",
                  Term::Application(VariableUP("y", 24), VariableUP("y", 24))});
+
+    kData.emplace_back(
+        TestData{"(l x. (l z. x z) x) y",
+                 Term::Application(VariableUP("y", 24), VariableUP("y", 24))});
 }
 
 void Run() {


### PR DESCRIPTION
Dear @KareemErgawy, excuse my intrusion, but I noticed your email on TYPES and took a quick look at your implementation of lambda calculus, but there's one thing I don't understand.

- I tried adding, as test program, `(l x. x x) y`, to test that it reduces to `y y`, but that doesn't seem to work.

- I added this program because I don't understand your implementation of substitution: when you substitute `x` by `t`, you *modify* `t` in place — but what if you need to substitute `t` for *another* occurrence of `x`? I didn't get how it worked, then I didn't find a test exercising this, so I added one. Then, I added a second that reuses variables under different sizes of binding contexts.

Modifying the term you're reducing in place is an unusual and interesting idea, but you need to be careful. The simplest correct solution is to copy the term `t` you are substituting before shifting it and substituting it. The copy must happen before substitution, in case other occurrences of `t` occur under another context.